### PR TITLE
Switch ci image from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: trusty
+dist: xenial
 sudo: required
 env:
     global:
@@ -29,6 +29,10 @@ before_install:
 
         if [ "$(docker version -f '{{.Server.Version}}')|sed -e 's/-ce.*$//'" !=
         "$(echo ${DOCKER_VERSION}|sed -e 's/~ce.*$//')" ] ; then
+            sudo add-apt-repository \
+                "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+                $(lsb_release -cs) \
+                stable"
             apt-cache madison docker-ce
             sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-ce=${DOCKER_VERSION}
         else


### PR DESCRIPTION
https://docs.docker.com/install/linux/docker-ce/ubuntu/#uninstall-old-versions